### PR TITLE
Clean out the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,9 @@
 # Ignore configuration files that may contain sensitive information.
-files/*
 sites/*/settings*.php
 
 # Ignore paths that contain user-generated content.
 sites/*/files
 sites/*/private
 
-
-#idea - PhpStorm
-
-.idea
-
-
-#Den
-dhu.node
-.ht-php-error.log
-
-#sass cache dirs
-.sass-cache
-
-.htaccess.loc
-
-# sajat fejlesztoi gepen modulok
-sites/all/modules/dev
+# Ignore the Drupal 6 style files directory.
+files/*


### PR DESCRIPTION
Some exclusion in the root `.gitignore` could be elsewhere to keep the core upgrade easy.

I think only one line is necessary besides the original lines.
`files/*`

The best way to exclude the IDE/TextEditor files is add the following lines to `~/.gitconfig`.

``` ini
[core]
    excludesfile = ~/.gitignore
```

And create file like this: https://gist.github.com/Sweetchuck/6143692
