### PR TITLE
PHP Warnings on job offer list page.

### DIFF
--- a/sites/all/themes/demon/templates/views/views-view--job--page.tpl.php
+++ b/sites/all/themes/demon/templates/views/views-view--job--page.tpl.php
@@ -34,7 +34,7 @@
   <?php endif; ?>
   <?php print render($title_suffix); ?>
   
-  <?php print job_link(); ?>
+  <?php print job_link($variables); ?>
   
   <?php if ($header): ?>
     <div class="view-header">


### PR DESCRIPTION
- Warning: Missing argument 1 for job_link(), called in /.../sites/all/themes/demon/templates/views/views-view--job--page.tpl.php on line 37 and defined in job_link() (line 252 of /.../web/sites/all/themes/demon/template.php).
- Notice: Undefined variable: variables in job_link() (line 253 of /.../web/sites/all/themes/demon/template.php).
