### PR TITLE
Create private directory if not exists

### DIFF
--- a/scripts/docker-init.sh
+++ b/scripts/docker-init.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal;"
+if [ ! -d /var/www/html/sites/default/files/private ]
+then
+  mkdir /var/www/html/sites/default/files/private
+  chown www-data.www-data /var/www/html/sites/default/files/private
+fi
 echo "=================================================="
 echo
 echo " Pranacssorhoz futtasd a következő parancsot:"


### PR DESCRIPTION
A .gitignore egy picit strict lett, ezért maga a private könyvtár sincs benne a repoban, és a Drupal nem hozza létre szemben a többi könyvtárral. (legalább is nálam csak így működött jól)
