### PR TITLE
Blockquote style refactor

### DIFF
--- a/docroot/sites/all/themes/demon/css/style.css
+++ b/docroot/sites/all/themes/demon/css/style.css
@@ -1017,27 +1017,12 @@ li.search-result h3 {
 
 blockquote {
   font-style: italic;
-  position: relative;
-  margin: 0.25em 0;
-  padding: 0.25em 40px;
+  margin: 0 0 20px;
+  padding: 10px 20px;
+  border-left: 5px solid #eee;
 }
-blockquote:before {
-  display: block;
-  content: "\201C";
-  font-size: 80px;
-  position: absolute;
-  left: -10px;
-  top: 20px;
-  color: #7a7a7a;
-}
-blockquote:after {
-  display: block;
-  content: "\201d";
-  font-size: 80px;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  color: #7a7a7a;
+blockquote p {
+  margin-bottom: 0;
 }
 
 /**


### PR DESCRIPTION
### A hiba

Az idézet nem mindig hosszú, így van amikor a kép mellett semmi nem látszik csak az idézet 'jelének' másik fele, sőt ha csak egy mondat akkor még bele is lóg a képbe  
![idezet_hiba](https://cloud.githubusercontent.com/assets/2457274/5559490/d768ebca-8d4f-11e4-9423-11c266ac36aa.png)

itt a túl rövid verzió

![idezet_tul_rovid](https://cloud.githubusercontent.com/assets/2457274/5559506/1e4f565a-8d50-11e4-8616-f53dac6e38d4.png)
### Javaslat

Szóval **egyszerűsíteném** a megjelenést és ez megoldaná a túl rövid idézet problémáját is:

![screen shot 2014-12-26 at 22 41 37](https://cloud.githubusercontent.com/assets/2457274/5559510/6b149a54-8d50-11e4-8727-2b3592044562.png)
![screen shot 2014-12-26 at 22 41 48](https://cloud.githubusercontent.com/assets/2457274/5559511/6b1873ae-8d50-11e4-8c36-7acb39d1ecd3.png)
