### PR TITLE
#155 fix link checker

### DIFF
--- a/docroot/sites/all/modules/custom/dhu_drupalcheck/dhu_drupalcheck.module
+++ b/docroot/sites/all/modules/custom/dhu_drupalcheck/dhu_drupalcheck.module
@@ -97,7 +97,7 @@ function dhu_drupalcheck_form_link_node_form_alter(&$form, &$form_state) {
  */
 function dhu_drupalcheck_form_link_node_form_alter_validate($element, &$form_state, $form) {
   if (!dhu_drupalcheck_check($element['#value']['url'])) {
-    drupal_set_message($element, t('This URL does not point to a Drupal site. We are accepting only Drupal sites. Sorry.'));
+    drupal_set_message(t('This URL does not point to a Drupal site. We are accepting only Drupal sites. Sorry.'), 'error');
   }
 }
 


### PR DESCRIPTION
Elnézést, elsőre nagyon hebehurgya és figyelmetlen voltam, azért két kommit. Ahogy az issueban javasolta pp, a form_set_error helyett drupal_set_message van, ha a link nem tűnik drupal oldalnak. Ez így messze van a végleges megoldástól de legalább nem lehetetleníti el a link beküldést.
