### PR TITLE
Issue #233 - PHP verziók frissítése a .travis.yml fájlban.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
 
 matrix:


### PR DESCRIPTION
Issue #233

Eltávolítottam a PHP 5.4-es verziót mivel az Acquia hostingon 5.5 a legkisebb ami elérhető, viszont a PHP 5.6-ot nem adtam hozzá, mert a Travis build jelenleg annyit csinál, hogy futtatja a _Webform_ modul tesztjeit, amiből megtudjuk, hogy az alap Core és a Webform modul működik-e.